### PR TITLE
Fixed borked substack urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ class AWSNestedStacks {
         ref.self.serverlessLog('Creating nested stacks in Cloudformation...')
         let stacks = ref.self.serverless.service.custom['nested-stacks'].stacks
         if (stacks) {
-            const baseUrl = ref.self.getBaseUrl()
             let resources = ref.self.serverless.service.provider.compiledCloudFormationTemplate.Resources
             for (let stack of stacks) {
                 if (stack && stack.id && stack.template) {
@@ -88,7 +87,7 @@ class AWSNestedStacks {
                     resources[stack.id] = {
                         'Type': 'AWS::CloudFormation::Stack',
                         'Properties': {
-                            'TemplateURL': ref.self.getTemplateUrl(baseUrl, stack)
+                            'TemplateURL': ref.self.getTemplateUrl(ref.self.getBaseUrl(), stack)
                         }
                     }
                     if (stack.notifications) {


### PR DESCRIPTION
When using multiple substacks, the template url for the second, third, etc. stacks will be garbage. This is because the `const baseUrl` will be overwritten in the (js) stack during runtime. this will result in:

```json
    "CloudHealth": {
      "Type": "AWS::CloudFormation::Stack",
      "Properties": {
        "TemplateURL": {
          "Fn::Sub": "https://s3.amazonaws.com/${ServerlessDeploymentBucket}/serverless/halloumi-landingzone/dev/cloudhealth.yml/hardening.yml"
        },
      }
    },
    "Hardening": {
      "Type": "AWS::CloudFormation::Stack",
      "Properties": {
        "TemplateURL": {
          "$ref": "$[\"Resources\"][\"CloudHealth\"][\"Properties\"][\"TemplateURL\"]"
        },
      }
    }
  },
```
Removing the const, and just fetching the baseUrl each time fixes this issue.