### PR TITLE
Add DependsOn attribute handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ custom:
 * **custom.nested-stacks.stacks.parameters** - A list of key value pairs to be passed into the nested stack as parameters.
 * **custom.nested-stacks.stacks.tags** - A list of key value pairs to be passed into the nested stack as its tags.
 * **custom.nested-stacks.stacks.notifications** - A list of existing Amazon SNS topics where notifications about stack events are sent.
+* **custom.nested-stacks.stacks.dependson** - The ID of another CloudFormation resource. Specify another stack ID to order the application of nested stacks.
 
 ## Want to know more?
 

--- a/index.js
+++ b/index.js
@@ -116,6 +116,9 @@ class AWSNestedStacks {
                     if (stack.timeout) {
                         resources[stack.id].Properties.TimeoutInMinutes = stack.timeout
                     }
+                    if (stack.dependson) {
+                        resources[stack.id].DependsOn = stack.dependson
+                    }
                 } else {
                     const msg = ('Missing required properties for nested stack:\n' +
                                  '\tid - Logical ID of the nested stack\n' +


### PR DESCRIPTION
This way you can order stack application  Useful if stack A creates a resource you need to reference in stack B.